### PR TITLE
feat: add footer for ICP info

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,6 @@ FORWARDED_ALLOW_IPS='*'
 SCARF_NO_ANALYTICS=true
 DO_NOT_TRACK=true
 ANONYMIZED_TELEMETRY=false
+
+# Optional ICP record number displayed in the UI footer
+VITE_ICP_INFO=""

--- a/src/lib/components/layout/Footer.svelte
+++ b/src/lib/components/layout/Footer.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+        import { ICP_INFO } from '$lib/constants';
+</script>
+
+{#if ICP_INFO}
+        <footer class="w-full text-center text-xs text-gray-500 dark:text-gray-400 py-4">
+                <a href="https://beian.miit.gov.cn" target="_blank" rel="noopener">{ICP_INFO}</a>
+        </footer>
+{/if}
+

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -16,6 +16,7 @@ export const RETRIEVAL_API_BASE_URL = `${WEBUI_BASE_URL}/api/v1/retrieval`;
 export const WEBUI_VERSION = APP_VERSION;
 export const WEBUI_BUILD_HASH = APP_BUILD_HASH;
 export const REQUIRED_OLLAMA_VERSION = '0.1.16';
+export const ICP_INFO = (import.meta.env as any).VITE_ICP_INFO || '';
 
 export const SUPPORTED_FILE_TYPE = [
 	'application/epub+zip',

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -43,9 +43,10 @@
 	import i18n, { initI18n, getLanguages, changeLanguage } from '$lib/i18n';
 	import { bestMatchingLanguage } from '$lib/utils';
 	import { getAllTags, getChatList } from '$lib/apis/chats';
-	import NotificationToast from '$lib/components/NotificationToast.svelte';
-	import AppSidebar from '$lib/components/app/AppSidebar.svelte';
-	import { chatCompletion } from '$lib/apis/openai';
+        import NotificationToast from '$lib/components/NotificationToast.svelte';
+        import AppSidebar from '$lib/components/app/AppSidebar.svelte';
+        import Footer from '$lib/components/layout/Footer.svelte';
+        import { chatCompletion } from '$lib/apis/openai';
 
 	import { beforeNavigate } from '$app/navigation';
 	import { updated } from '$app/state';
@@ -665,18 +666,19 @@
 				<slot />
 			</div>
 		</div>
-	{:else}
-		<slot />
-	{/if}
+        {:else}
+                <slot />
+                <Footer />
+        {/if}
 {/if}
 
 <Toaster
-	theme={$theme.includes('dark')
-		? 'dark'
-		: $theme === 'system'
-			? window.matchMedia('(prefers-color-scheme: dark)').matches
-				? 'dark'
-				: 'light'
+        theme={$theme.includes('dark')
+                ? 'dark'
+                : $theme === 'system'
+                        ? window.matchMedia('(prefers-color-scheme: dark)').matches
+                                ? 'dark'
+                                : 'light'
 			: 'light'}
 	richColors
 	position="top-right"


### PR DESCRIPTION
## Summary
- add `VITE_ICP_INFO` env option to expose ICP record info
- show optional ICP footer component across the web UI

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run test:frontend` (fails: sh: 1: vitest: not found)
- `npm run lint` (fails: ESLint couldn't find an eslint.config file; svelte-kit not found; pylint not found)


------
https://chatgpt.com/codex/tasks/task_e_6891e13d6f748327a4c41af7a38bb77e