### PR TITLE
feat: add configurable ICP footer

### DIFF
--- a/src/lib/components/layout/Footer.svelte
+++ b/src/lib/components/layout/Footer.svelte
@@ -1,9 +1,11 @@
 <script lang="ts">
         import { ICP_INFO } from '$lib/constants';
+
+        export let class: string = '';
 </script>
 
 {#if ICP_INFO}
-        <footer class="w-full text-center text-xs text-gray-500 dark:text-gray-400 py-4">
+        <footer class={`w-full text-center text-xs text-gray-500 dark:text-gray-400 py-4 ${class}`}>
                 <a href="https://beian.miit.gov.cn" target="_blank" rel="noopener">{ICP_INFO}</a>
         </footer>
 {/if}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -658,17 +658,20 @@
 </svelte:head>
 
 {#if loaded}
-	{#if $isApp}
-		<div class="flex flex-row h-screen">
-			<AppSidebar />
+        {#if $isApp}
+                <div class="flex flex-row h-screen">
+                        <AppSidebar />
 
-			<div class="w-full flex-1 max-w-[calc(100%-4.5rem)]">
-				<slot />
-			</div>
-		</div>
+                        <div class="w-full flex-1 max-w-[calc(100%-4.5rem)] flex flex-col">
+                                <div class="flex-1 overflow-hidden">
+                                        <slot />
+                                </div>
+                                <Footer />
+                        </div>
+                </div>
         {:else}
                 <slot />
-                <Footer />
+                <Footer class="fixed bottom-0 left-0 right-0 z-[100]" />
         {/if}
 {/if}
 


### PR DESCRIPTION
## Summary
- allow passing classes to ICP footer component
- show ICP footer at bottom of login and app content areas

## Testing
- `npm test` (fails: Missing script)
- `npm run test:frontend` (fails: vitest not found)
- `npm install --legacy-peer-deps` (fails: fetch failed for onnxruntime)


------
https://chatgpt.com/codex/tasks/task_e_6898b0a7d2d0832783ac8c009fb8bbea